### PR TITLE
자동으로 체크된 항목 다크패턴에서, 경고를 위한 dot UI가 제대로 표시되지 않는 문제 해결

### DIFF
--- a/scripts/highlighter.js
+++ b/scripts/highlighter.js
@@ -246,7 +246,13 @@ window.LightOn.Highlighter = (function() {
   function applyDot(element, pattern) {
     // Check if element can contain the dot properly
     const computedStyle = window.getComputedStyle(element);
-    const isInline = computedStyle.display === 'inline' ||
+
+    // Void elements cannot have children (input, img, br, etc.)
+    const voidElements = ['INPUT', 'IMG', 'BR', 'HR', 'AREA', 'BASE', 'COL', 'EMBED', 'SOURCE', 'TRACK', 'WBR'];
+    const isVoidElement = voidElements.includes(element.tagName);
+
+    const isInline = isVoidElement ||
+                     computedStyle.display === 'inline' ||
                      computedStyle.display === 'inline-block' ||
                      element.tagName === 'A' ||
                      element.tagName === 'SPAN';
@@ -257,7 +263,7 @@ window.LightOn.Highlighter = (function() {
     const dot = createDot(pattern, element);
 
     if (isInline) {
-      // For inline elements, insert dot after the element
+      // For inline elements and void elements, insert dot after the element
       dot.classList.add('lighton-dot--inline');
       element.parentNode.insertBefore(dot, element.nextSibling);
     } else {


### PR DESCRIPTION
자동으로 체크된 항목 다크패턴에서, 경고를 위한 dot UI가 제대로 표시되지 않는 문제 해결했습니다.

원인은 아래와 같습니다.
Void elements (input, img, etc.) cannot have children via appendChild. Now correctly inserts dot after the element instead of trying to append.