### PR TITLE
체크박스 관련 오류 수정: 다크패턴 중복 카운트와 결제창 자동선택 하이라이트 안됨

### DIFF
--- a/scripts/detector.js
+++ b/scripts/detector.js
@@ -394,8 +394,9 @@ window.LightOn.Detector = (function() {
   }
 
   /**
-   * Remove duplicate detections where parent and child both match the same pattern
-   * Keeps the most specific (smallest/deepest) element
+   * Remove duplicate detections where:
+   * 1. Same element matched by multiple selectors/detectors for the same pattern
+   * 2. Parent and child both match the same pattern (keeps the most specific element)
    */
   function deduplicateResults(results) {
     // Group results by pattern ID
@@ -411,18 +412,29 @@ window.LightOn.Detector = (function() {
     const deduplicated = [];
 
     for (const [patternId, patternResults] of byPattern) {
-      if (patternResults.length === 1) {
-        deduplicated.push(patternResults[0]);
+      // Step 1: Remove same-element duplicates using Set
+      const seenElements = new Set();
+      const uniqueResults = [];
+
+      for (const result of patternResults) {
+        if (!seenElements.has(result.element)) {
+          seenElements.add(result.element);
+          uniqueResults.push(result);
+        }
+      }
+
+      if (uniqueResults.length === 1) {
+        deduplicated.push(uniqueResults[0]);
         continue;
       }
 
-      // For each result, check if any other result's element is its ancestor
+      // Step 2: For each result, check if any other result's element is its ancestor
       const toKeep = [];
 
-      for (const result of patternResults) {
+      for (const result of uniqueResults) {
         let hasDescendantMatch = false;
 
-        for (const other of patternResults) {
+        for (const other of uniqueResults) {
           if (other === result) continue;
 
           // Check if 'other' element is a descendant of 'result' element

--- a/scripts/patterns/interface.js
+++ b/scripts/patterns/interface.js
@@ -66,7 +66,7 @@
         {
           type: DETECTOR_TYPES.SELECTOR,
           selectors: [
-            'input[type="checkbox"][checked]',
+            // :checked captures both HTML [checked] attribute and dynamic state
             'input[type="checkbox"]:checked'
           ],
           nearbyTextPatterns: [

--- a/scripts/patterns/sneaking.js
+++ b/scripts/patterns/sneaking.js
@@ -117,8 +117,7 @@
         {
           type: DETECTOR_TYPES.SELECTOR,
           selectors: [
-            // Pre-selected add-ons in cart context
-            'input[type="checkbox"][checked]',
+            // :checked captures both HTML [checked] attribute and dynamic state
             'input[type="checkbox"]:checked'
           ],
           contextSelectors: [
@@ -148,7 +147,7 @@
         }
       ],
       highlight: {
-        style: HIGHLIGHT_STYLES.BADGE,
+        style: HIGHLIGHT_STYLES.OUTLINE,
         color: SEVERITY.HIGH,
         icon: '🛒'
       }


### PR DESCRIPTION
체크박스가 카운트될때 셀렉터 오류로 두개씩 카운트 되는 것과, 자동추가 옵션 border line 안보이는 오류 수정

- Remove duplicate CSS selectors ([checked] + :checked) in interface.js and sneaking.js
- Add same-element deduplication in detector.js deduplicateResults()
- Change auto-add-cart highlight style from BADGE to OUTLINE for border visibility
<img width="326" height="415" alt="image" src="https://github.com/user-attachments/assets/f8089408-7126-458f-97d7-a8680ee57fe8" />
